### PR TITLE
$_SESSION['_opauth_twitter'] not existing PHP error

### DIFF
--- a/TwitterStrategy.php
+++ b/TwitterStrategy.php
@@ -92,10 +92,16 @@ class TwitterStrategy extends OpauthStrategy {
 		if (!session_id()) {
 			session_start();
 		}
-		$session = $_SESSION['_opauth_twitter'];
-		unset($_SESSION['_opauth_twitter']);
+		
+		$session = null;
+		if (array_key_exists('_opauth_twitter', $_SESSION)) {
+			$session = $_SESSION['_opauth_twitter'];
+			unset($_SESSION['_opauth_twitter']);
+		}
 
-		if (!empty($_REQUEST['oauth_token']) && $_REQUEST['oauth_token'] == $session['oauth_token']) {
+		if (is_array($session) &&
+			!empty($_REQUEST['oauth_token']) && 
+			$_REQUEST['oauth_token'] == $session['oauth_token']) {
 			$this->tmhOAuth->config['user_token'] = $session['oauth_token'];
 			$this->tmhOAuth->config['user_secret'] = $session['oauth_token_secret'];
 			

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
-	"name": "xylesoft/twitter",
+	"name": "opauth/twitter",
 	"description": "Twitter strategy for Opauth",
-	"keywords": ["authentication","auth","twitter","forked"],
+	"keywords": ["authentication","auth","twitter"],
 	"homepage": "http://opauth.org",
 	"license": "MIT",
 	"authors": [
@@ -9,10 +9,6 @@
 			"name": "U-Zyn Chua",
 			"email": "chua@uzyn.com",
 			"homepage": "http://uzyn.com"
-		},
-		{
-			"name": "Jeramy Wenserit",
-			"email": "jeramy@xylesoft.co.uk"
 		}
 	],
 	"require": {

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
-	"name": "opauth/twitter",
+	"name": "xylesoft/twitter",
 	"description": "Twitter strategy for Opauth",
-	"keywords": ["authentication","auth","twitter"],
+	"keywords": ["authentication","auth","twitter","forked"],
 	"homepage": "http://opauth.org",
 	"license": "MIT",
 	"authors": [
@@ -9,6 +9,10 @@
 			"name": "U-Zyn Chua",
 			"email": "chua@uzyn.com",
 			"homepage": "http://uzyn.com"
+		},
+		{
+			"name": "Jeramy Wenserit",
+			"email": "jeramy@xylesoft.co.uk",
 		}
 	],
 	"require": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 		},
 		{
 			"name": "Jeramy Wenserit",
-			"email": "jeramy@xylesoft.co.uk",
+			"email": "jeramy@xylesoft.co.uk"
 		}
 	],
 	"require": {


### PR DESCRIPTION
There are some niche situations where $_SESSION['_opauth_twitter'] is undefined, in oauth_callback() it calls:
     
    $session = $_SESSION['_opauth_twitter'];

If the session array key does not exist, it will throw a PHP error. This pull request adds a small test to see if the array key exists before attempting to execute the fragile code.

