### PR TITLE
Using HTTPs url for profile images

### DIFF
--- a/TwitterStrategy.php
+++ b/TwitterStrategy.php
@@ -128,7 +128,7 @@ class TwitterStrategy extends OpauthStrategy {
 					
 					$this->mapProfile($credentials, 'location', 'info.location');
 					$this->mapProfile($credentials, 'description', 'info.description');
-					$this->mapProfile($credentials, 'profile_image_url', 'info.image');
+					$this->mapProfile($credentials, 'profile_image_url_https', 'info.image');
 					$this->mapProfile($credentials, 'url', 'info.urls.website');
 					
 					$this->callback();


### PR DESCRIPTION
Its better to use HTTPs url for the profile images. So updated profile_image_url to profile_image_url_https.